### PR TITLE
feat: add PaymentInfo support for Platnosc element

### DIFF
--- a/src/ksef/models/invoice.py
+++ b/src/ksef/models/invoice.py
@@ -206,6 +206,30 @@ class AdditionalDescription(BaseModel):
     row_number: Optional[int] = None
 
 
+# FormaPlatnosci enum values (TFormaPlatnosci in FA(3) schema)
+PAYMENT_METHOD_CASH = 1  # gotówka
+PAYMENT_METHOD_CARD = 2  # karta
+PAYMENT_METHOD_VOUCHER = 3  # bon
+PAYMENT_METHOD_CHECK = 4  # czek
+PAYMENT_METHOD_CREDIT = 5  # kredyt
+PAYMENT_METHOD_BANK_TRANSFER = 6  # przelew
+PAYMENT_METHOD_MOBILE = 7  # mobilna
+
+
+class PaymentInfo(BaseModel):
+    """Payment information for the invoice (Platnosc element in Fa section).
+
+    All fields are optional — include only those that apply.
+    """
+
+    is_paid: bool = False  # Zaplacono — flag "1" if fully paid
+    payment_date: Optional[date] = None  # DataZaplaty — date of payment
+    due_date: Optional[date] = None  # TerminPlatnosci > Termin — due date
+    due_description: Optional[str] = None  # TerminPlatnosci > TerminOpis
+    method: Optional[int] = None  # FormaPlatnosci — use PAYMENT_METHOD_* constants
+    bank_account_number: Optional[str] = None  # RachunekBankowy > NrRB
+
+
 class InvoiceData(BaseModel):
     """Invoice data.
 
@@ -222,6 +246,7 @@ class InvoiceData(BaseModel):
     invoice_type: InvoiceType
     additional_descriptions: Sequence[AdditionalDescription] = ()
     invoice_rows: InvoiceRows
+    payment_info: Optional[PaymentInfo] = None
 
 
 class Invoice(BaseModel):

--- a/src/ksef/xml_converters.py
+++ b/src/ksef/xml_converters.py
@@ -9,6 +9,7 @@ from ksef.models.invoice import (
     Invoice,
     NipIdentification,
     NoIdentification,
+    PaymentInfo,
 )
 
 # FA(3) schema namespace
@@ -250,6 +251,35 @@ def _build_additional_descriptions(parent: ElementTree.Element, invoice: Invoice
         ElementTree.SubElement(dodatkowy_opis, "Wartosc").text = desc.value
 
 
+def _build_payment_info(parent: ElementTree.Element, payment: PaymentInfo) -> None:
+    """Emit Platnosc element with payment details."""
+    platnosc = ElementTree.SubElement(parent, "Platnosc")
+
+    if payment.is_paid:
+        ElementTree.SubElement(platnosc, "Zaplacono").text = "1"
+
+    if payment.payment_date is not None:
+        ElementTree.SubElement(platnosc, "DataZaplaty").text = payment.payment_date.strftime(
+            "%Y-%m-%d"
+        )
+
+    if payment.due_date is not None or payment.due_description is not None:
+        termin_platnosci = ElementTree.SubElement(platnosc, "TerminPlatnosci")
+        if payment.due_date is not None:
+            ElementTree.SubElement(termin_platnosci, "Termin").text = payment.due_date.strftime(
+                "%Y-%m-%d"
+            )
+        if payment.due_description is not None:
+            ElementTree.SubElement(termin_platnosci, "TerminOpis").text = payment.due_description
+
+    if payment.method is not None:
+        ElementTree.SubElement(platnosc, "FormaPlatnosci").text = str(payment.method)
+
+    if payment.bank_account_number is not None:
+        rachunek = ElementTree.SubElement(platnosc, "RachunekBankowy")
+        ElementTree.SubElement(rachunek, "NrRB").text = payment.bank_account_number
+
+
 def _build_invoice_rows(parent: ElementTree.Element, invoice: Invoice) -> None:
     """Emit FaWiersz elements for each invoice row."""
     for index, row in enumerate(invoice.invoice_data.invoice_rows.rows, start=1):
@@ -304,6 +334,9 @@ def _build_invoice_data(root: ElementTree.Element, invoice: Invoice) -> None:
 
     _build_additional_descriptions(invoice_data, invoice)
     _build_invoice_rows(invoice_data, invoice)
+
+    if invoice.invoice_data.payment_info is not None:
+        _build_payment_info(invoice_data, invoice.invoice_data.payment_info)
 
 
 def convert_invoice_to_xml(invoice: Invoice, invoicing_software_name: str = "python-ksef") -> bytes:

--- a/tests/xml_converters/test_convert_invoice_to_xml.py
+++ b/tests/xml_converters/test_convert_invoice_to_xml.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from bs4 import BeautifulSoup
 
 from ksef.models.invoice import (
+    PAYMENT_METHOD_BANK_TRANSFER,
+    PAYMENT_METHOD_CARD,
+    PAYMENT_METHOD_CASH,
     Address,
     EuVatIdentification,
     ForeignIdentification,
@@ -16,6 +19,7 @@ from ksef.models.invoice import (
     IssuerIdentificationData,
     NipIdentification,
     NoIdentification,
+    PaymentInfo,
     Subject,
     SubjectIdentificationData,
 )
@@ -272,3 +276,79 @@ def test_recipient_with_name() -> None:
     podmiot2 = soup.find("Podmiot2")
     assert podmiot2.find("DaneIdentyfikacyjne").find("NIP").text == "2222222222"
     assert podmiot2.find("Nazwa").text == "Firma Testowa Sp. z o.o."
+
+
+def _make_invoice_with_payment(payment_info: PaymentInfo) -> Invoice:
+    """Build a minimal invoice with the given payment info."""
+    invoice = _make_invoice(Subject(identification_data=NipIdentification(nip="2222222222")))
+    invoice.invoice_data.payment_info = payment_info
+    return invoice
+
+
+def test_payment_info_omitted() -> None:
+    """Platnosc element is not emitted when payment_info is None."""
+    invoice = _make_invoice(Subject(identification_data=NipIdentification(nip="2222222222")))
+    xml = convert_invoice_to_xml(invoice)
+    soup = BeautifulSoup(xml, "xml")
+    assert soup.find("Platnosc") is None
+
+
+def test_payment_info_bank_transfer_with_due_date() -> None:
+    """Bank transfer invoice emits FormaPlatnosci=6, Termin and RachunekBankowy."""
+    invoice = _make_invoice_with_payment(
+        PaymentInfo(
+            due_date=date(2024, 2, 5),
+            method=PAYMENT_METHOD_BANK_TRANSFER,
+            bank_account_number="12345678901234567890123456",
+        )
+    )
+    soup = BeautifulSoup(convert_invoice_to_xml(invoice), "xml")
+    platnosc = soup.find("Platnosc")
+    assert platnosc is not None
+    assert platnosc.find("Zaplacono") is None
+    assert platnosc.find("DataZaplaty") is None
+    assert platnosc.find("TerminPlatnosci").find("Termin").text == "2024-02-05"
+    assert platnosc.find("FormaPlatnosci").text == "6"
+    assert platnosc.find("RachunekBankowy").find("NrRB").text == "12345678901234567890123456"
+
+
+def test_payment_info_paid_in_full() -> None:
+    """Already-paid invoice emits Zaplacono=1 and DataZaplaty."""
+    invoice = _make_invoice_with_payment(
+        PaymentInfo(
+            is_paid=True,
+            payment_date=date(2024, 1, 22),
+            method=PAYMENT_METHOD_CASH,
+        )
+    )
+    soup = BeautifulSoup(convert_invoice_to_xml(invoice), "xml")
+    platnosc = soup.find("Platnosc")
+    assert platnosc.find("Zaplacono").text == "1"
+    assert platnosc.find("DataZaplaty").text == "2024-01-22"
+    assert platnosc.find("FormaPlatnosci").text == "1"
+    assert platnosc.find("RachunekBankowy") is None
+
+
+def test_payment_info_with_due_description() -> None:
+    """Due date with custom description emits both Termin and TerminOpis."""
+    invoice = _make_invoice_with_payment(
+        PaymentInfo(
+            due_date=date(2024, 3, 1),
+            due_description="14 dni od otrzymania faktury",
+            method=PAYMENT_METHOD_CARD,
+        )
+    )
+    soup = BeautifulSoup(convert_invoice_to_xml(invoice), "xml")
+    termin_platnosci = soup.find("Platnosc").find("TerminPlatnosci")
+    assert termin_platnosci.find("Termin").text == "2024-03-01"
+    assert termin_platnosci.find("TerminOpis").text == "14 dni od otrzymania faktury"
+    assert soup.find("FormaPlatnosci").text == "2"
+
+
+def test_payment_info_is_paid_false_omits_zaplacono() -> None:
+    """Zaplacono element is not emitted when is_paid is False (default)."""
+    invoice = _make_invoice_with_payment(PaymentInfo(method=PAYMENT_METHOD_BANK_TRANSFER))
+    soup = BeautifulSoup(convert_invoice_to_xml(invoice), "xml")
+    platnosc = soup.find("Platnosc")
+    assert platnosc is not None
+    assert platnosc.find("Zaplacono") is None


### PR DESCRIPTION
## Summary

Adds support for the `<Platnosc>` element (payment details) in the `Fa` section of the FA(3) schema.

## What's new

- **`PaymentInfo` model** with:
  - `is_paid: bool` — emits `<Zaplacono>1</Zaplacono>` flag when True
  - `payment_date` — `<DataZaplaty>`
  - `due_date` + `due_description` — `<TerminPlatnosci>` / `<Termin>` / `<TerminOpis>`
  - `method` — `<FormaPlatnosci>` (use `PAYMENT_METHOD_*` constants)
  - `bank_account_number` — `<RachunekBankowy>` / `<NrRB>`
- **Payment method constants** matching `TFormaPlatnosci` enum:
  - `PAYMENT_METHOD_CASH` (1), `CARD` (2), `VOUCHER` (3), `CHECK` (4), `CREDIT` (5), `BANK_TRANSFER` (6), `MOBILE` (7)
- **Optional `payment_info`** field on `InvoiceData`
- **XML serializer** `_build_payment_info()` emitting elements in schema order: `Zaplacono` → `DataZaplaty` → `TerminPlatnosci` → `FormaPlatnosci` → `RachunekBankowy`

## Note on `Zaplacono`

Initial attempt treated `Zaplacono` as a decimal amount, which KSeF rejected:
> The value '100.00' is invalid according to its datatype 'TWybor1' - The string '100.00' is not a valid SByte value.

`TWybor1` is a flag type accepting only value `1`. The actual paid amount is implied from `P_15` when the flag is set.

## Test plan

- [x] Existing 36 library tests pass
- [x] Verified against KSeF test environment with 9 invoice variations (paid/unpaid, various methods)